### PR TITLE
[ci skip] adding user @roederja

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @roederja2
+* @roederja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,4 +40,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - roederja
     - roederja2


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @roederja as instructed in #13.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #13