### PR TITLE
Fixed msal constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<37]
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - libsecret  # [not win]
-    - msal >=1.2.9,<2.0
+    - msal >=1.29,<2.0
     - portalocker >=1.6,<3.0
     - pygobject >=3,<4  # [not win]
 


### PR DESCRIPTION
The dependency update in #28 contained a typo, unfortunately. The upstream repo has a dependency on `msal>=1.29`, but in the recipe here it was changed to `msal>=1.2.9` instead. The current package in `conda-forge` is quite broken if/when you end up with such an old version of `msal`, e.g. continuously re-prompting in device flow.